### PR TITLE
LoginActivity on non-xhdpi screens

### DIFF
--- a/res/layout/register.xml
+++ b/res/layout/register.xml
@@ -1,81 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="fill_parent"
-  android:fillViewport="true">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:fillViewport="true" >
 
- <RelativeLayout
-     android:layout_width="fill_parent"
-     android:layout_height="wrap_content"
-     android:background="#fff" >
+    <LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/linearLayout1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="10dip" >
 
-     <LinearLayout
-         xmlns:android="http://schemas.android.com/apk/res/android"
-         android:id="@+id/linearLayout1"
-         android:layout_width="match_parent"
-         android:layout_height="wrap_content"
-         android:layout_alignParentTop="true"
-         android:orientation="vertical"
-         android:padding="10dip" >
+        <TextView
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/register_password_textview"
+            android:textColor="#372c24" />
 
-         <TextView
-             android:layout_width="fill_parent"
-             android:layout_height="wrap_content"
-             android:text="@string/register_password_textview"
-             android:textColor="#372c24" />
+        <EditText
+            android:id="@+id/reg_password"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dip"
+            android:inputType="textPassword"
+            android:singleLine="true" />
 
-         <EditText
-             android:id="@+id/reg_password"
-             android:layout_width="fill_parent"
-             android:layout_height="wrap_content"
-             android:layout_marginTop="5dip"
-             android:inputType="textPassword"
-             android:singleLine="true" />
+        <TextView
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/register_password_confirm_textview"
+            android:textColor="#372c24" />
 
-         <TextView
-             android:layout_width="fill_parent"
-             android:layout_height="wrap_content"
-             android:text="@string/register_password_confirm_textview"
-             android:textColor="#372c24" />
+        <EditText
+            android:id="@+id/reg_password_confirm"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dip"
+            android:inputType="textPassword"
+            android:singleLine="true" />
 
-         <EditText
-             android:id="@+id/reg_password_confirm"
-             android:layout_width="fill_parent"
-             android:layout_height="wrap_content"
-             android:layout_marginTop="5dip"
-             android:inputType="textPassword"
-             android:singleLine="true" />
-     </LinearLayout>
+        <CheckBox
+            android:id="@+id/disablePassword"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="onCheckboxClicked"
+            android:text="@string/register_password_checkbox_summary" />
 
-     <Button
-         android:id="@+id/btnRegister"
-         android:layout_width="fill_parent"
-         android:layout_height="wrap_content"
-         android:layout_alignParentBottom="true"
-         android:layout_alignParentLeft="true"
-         android:text="@string/register_password_button" />
+        <TextView
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="14dp"
+            android:gravity="center_horizontal"
+            android:text="@string/register_password_summary"
+            android:textColor="#372c24" />
 
-     <TextView
-         android:layout_width="fill_parent"
-         android:layout_height="wrap_content"
-         android:layout_centerInParent="true"
-         android:gravity="center_horizontal" 
-         android:layout_below="@+id/linearLayout1"
-         android:layout_marginTop="54dp"
-         android:text="@string/register_password_summary"
-         android:textColor="#372c24" />
-
-     <CheckBox
-         android:id="@+id/disablePassword"
-         android:layout_width="wrap_content"
-         android:layout_height="wrap_content"
-         android:layout_alignParentLeft="true"
-         android:layout_alignParentRight="true"
-         android:onClick="onCheckboxClicked"
-         android:layout_below="@+id/linearLayout1"
-         android:text="@string/register_password_checkbox_summary" />
-
- </RelativeLayout>
+        <Button
+            android:id="@+id/btnRegister"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/register_password_button" />
+    </LinearLayout>
 
 </ScrollView>


### PR DESCRIPTION
Hi,

while playing around with with my old Samsung i9000 I noticed that LoginActivity overlapped the button and the help text, because there is not enough space on the screen while the keyboard is displayed.

![Screenshot1](http://i.imgur.com/u5Obem.jpeg)

I modified register.xml, removed the `RelativeLayout` and merged all elements into the previously nested `LinearLayout`. I also modified the Views to match the new layout.

It should look more or less the same on larger screens, but should now correctly scroll on smaller screens. I guess that was your original intention, since everything was wrapped in a `ScrollView`.

Please check it out, you might want to modify the details to your likings.

![Screenshot2](http://i.imgur.com/E4Fqkm.jpeg)

P.S.: Keep up the great work!
