### PR TITLE
Untranslated strings in PhoneTrackerActivity.java

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -12,6 +12,8 @@
     <string name="disable_tracking_button">"Standortverfolgung deaktivieren"</string>
     <string name="disable_tracking_prevent_back">Bitte schalten Sie die Standortverfolgung vor dem Schließen ab</string>
     <string name="tracking_returned_no_location">Standort konnte nicht erfasst werden</string>
+    <string name="tracking_address">Adresse:</string>
+    <string name="tracking_disabled">Verfolgung abgeschaltet</string>
     <string name="device_admin_reason">"aeGis benötigt Geräteadministratorrechte für die Löschen-/Sperren-Funktionen."</string>
     <string name="text_stub">"Zukünftige Funktionen!"</string>
     <string name="descr_overflow_button">"overflow"</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="disable_tracking_button">Disable Tracking</string>
     <string name="disable_tracking_prevent_back">Please disable tracking before exiting</string>
     <string name="tracking_returned_no_location">No Location Determined</string>
+    <string name="tracking_address">Address:</string>
+    <string name="tracking_disabled">Tracking Disabled</string>
     <string name="device_admin_reason">aeGis requires device admin control for the wipe/lock features.</string>
     <string name="text_stub">Features coming!</string>
     <string name="descr_overflow_button">overflow</string>

--- a/src/com/decad3nce/aegis/PhoneTrackerActivity.java
+++ b/src/com/decad3nce/aegis/PhoneTrackerActivity.java
@@ -183,7 +183,7 @@ public class PhoneTrackerActivity extends Activity implements LocationListener {
 
     public void disableTracking(View view) {
         final Button disableButton = (Button) findViewById(R.id.disable_tracking_button);
-        disableButton.setText("Tracking Disabled");
+        disableButton.setText(getResources().getString(R.string.tracking_disabled));
         mDisableTracking = true;
     }
 
@@ -337,7 +337,8 @@ public class PhoneTrackerActivity extends Activity implements LocationListener {
             if (addresses != null) {
                 Address returnedAddress = addresses.get(0);
                 StringBuilder strReturnedAddress = new StringBuilder(
-                        "Address:\n");
+                        getResources().getString(R.string.tracking_address));
+                strReturnedAddress.append("\n");
                 for (int i = 0; i < returnedAddress.getMaxAddressLineIndex(); i++) {
                     strReturnedAddress
                             .append(returnedAddress.getAddressLine(i)).append(


### PR DESCRIPTION
I found two untranslated strings in PhoneTrackerActivity.java and added them to the resources:

"Address:" as `tracking_address`
"Tracking Disabled" as `tracking_disabled`

I hope you don't mind.
