### PR TITLE
Add an option to not send the lock password in the SMS lock message.

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -4,6 +4,7 @@
     
     <bool name="config_default_lock_enabled">false</bool>
     <bool name="config_default_lock_wipe_pref">false</bool>
+    <bool name="config_default_send_password_in_sms_pref">false</bool>
     
     <bool name="config_default_data_enabled">false</bool>
     <bool name="config_default_data_backup_call_logs">true</bool>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -62,7 +62,9 @@
     <string name="preferences_lock_activation_sms_title">Lock Activation SMS</string>
     <string name="preferences_lock_activation_sms_summary">Choose what text to send to lock the device. It is recommended to use a PIN in your activation SMS to avoid unauthorized locking.</string>
     <string name="preferences_lock_password_title">Default password</string>
+    <string name="preferences_lock_password_send_in_sms_title">Send password in SMS</string>
     <string name="preferences_lock_password_summary">Choose what password will be used to lock the device. This is the default password that will be set, custom passwords can be provided when sending SMS by appending the requested password to the SMS. If set to blank, the password/lock method will not be changed but the device will get locked to force re-authentication using the existing password.</string>
+    <string name="preferences_lock_password_send_in_sms_summary">Include the password in the SMS text when when locking.</string>
     <string name="preferences_lock_wipe_pref_title">Wipe Device</string>
     <string name="preferences_lock_wipe_pref_summary">Whether to wipe device when activation SMS for lock tab is received by device.</string>
     <string name="preferences_data_category">Data</string>
@@ -92,6 +94,7 @@
     
     <string name="util_sendsms_alarm_pass">aeGis: Sound successfully enabled.</string>
     <string name="util_sendsms_alarm_fail">aeGis: Failed to override sound settings. Error:</string>
+    <string name="util_sendsms_lock_message">aeGis: Device successfully locked.</string>
     <string name="util_sendsms_lock_pass">aeGis: Locked device with password:</string>
     <string name="util_sendsms_lock_fail">aeGis: Failed to lock device. Error:</string>
     <string name="util_sendsms_data_recovery_pass">aeGis: Recovered file:</string>

--- a/res/xml/lock_preference.xml
+++ b/res/xml/lock_preference.xml
@@ -12,6 +12,10 @@
                 android:maxLength="16"
                 android:defaultValue="@string/config_default_lock_password"
                 android:inputType="textPassword" />
+        <CheckBoxPreference android:key="lock_send_password_in_sms_pref"
+                android:title="@string/preferences_lock_password_send_in_sms_title"
+                android:summary="@string/preferences_lock_password_send_in_sms_summary"
+                android:defaultValue="@bool/config_default_send_password_in_sms_pref" />
         <CheckBoxPreference android:key="lock_wipe_pref"
                 android:title="@string/preferences_lock_wipe_pref_title"
                 android:summary="@string/preferences_lock_wipe_pref_summary"

--- a/src/com/decad3nce/aegis/Fragments/SMSLockFragment.java
+++ b/src/com/decad3nce/aegis/Fragments/SMSLockFragment.java
@@ -18,6 +18,7 @@ public class SMSLockFragment extends PreferenceFragment {
 
     public static final String PREFERENCES_LOCK_ACTIVATION_SMS = "lock_activation_sms";
     public static final String PREFERENCES_LOCK_PASSWORD = "lock_password";
+    public static final String PREFERENCES_LOCK_SEND_PASSWORD_PREF = "lock_send_password_in_sms_pref";
     public static final String PREFERENCES_LOCK_WIPE_PREF = "lock_wipe_pref";
     public static final String PREFERENCES_LOCK_ENABLED = "lock_toggle";
 

--- a/src/com/decad3nce/aegis/Utils.java
+++ b/src/com/decad3nce/aegis/Utils.java
@@ -138,8 +138,15 @@ public class Utils {
             try {
                 Log.i(TAG, "Locking device");
                 devicePolicyManager.lockNow();
-                Utils.sendSMS(context, SMSReceiver.address,
-                        context.getResources().getString(R.string.util_sendsms_lock_pass) + " " + password);
+		        boolean sendPasswordInSMSEnabled  = preferences.getBoolean(
+		                SMSLockFragment.PREFERENCES_LOCK_SEND_PASSWORD_PREF,
+		                context.getResources().getBoolean(
+		                        R.bool.config_default_send_password_in_sms_pref));
+		        
+                String messageText = sendPasswordInSMSEnabled ?
+                		context.getResources().getString(R.string.util_sendsms_lock_pass) + " " + password :
+                		context.getResources().getString(R.string.util_sendsms_lock_message);
+                Utils.sendSMS(context, SMSReceiver.address, messageText);
             } catch (Exception e) {
                 Log.wtf(TAG, "Failed to lock device");
                 Log.wtf(TAG, e.toString());


### PR DESCRIPTION
I see you've changed things up in the current source a bit since the last released version on Google Play and that you've added an option to turn off the confirmation SMS completely but I'd still like to receive the confirmation, I just don't want it to contain the password. You don't have to merge this pull, just thought I'd create a pull request in case it was found useful. Also, I haven't done any Android development so beware, I don't really know what I'm doing. :-)

When the app receives an SMS to lock the device it sends a SMS response
informing the sender the device was locked. The password used to lock
the device is sent along with the confirmation. A checkbox now exists in
the lock settings to enable/disable the sending of the password in the
SMS response.
